### PR TITLE
feat: parallel read

### DIFF
--- a/tensorflow_io/core/BUILD
+++ b/tensorflow_io/core/BUILD
@@ -180,10 +180,10 @@ cc_library(
     srcs = [
         "kernels/bigtable/bigtable_dataset_kernel.cc",
         "kernels/bigtable/bigtable_resource_kernel.h",
-        "kernels/bigtable/bigtable_row_range.h",
-        "kernels/bigtable/bigtable_row_set.h",
         "kernels/bigtable/bigtable_row_range.cc",
+        "kernels/bigtable/bigtable_row_range.h",
         "kernels/bigtable/bigtable_row_set.cc",
+        "kernels/bigtable/bigtable_row_set.h",
         "ops/bigtable_ops.cc",
     ],
     copts = tf_io_copts(),

--- a/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
@@ -150,7 +150,7 @@ class Iterator : public DatasetIterator<Dataset> {
         columns_(ColumnsToFamiliesAndQualifiers(columns)),
         table_(this->dataset()->client_resource().CreateTable(table_id)),
         reader_(this->table_.ReadRows(
-            this->dataset()->row_set_resource()->row_set(),
+            this->dataset()->row_set_resource().row_set(),
             // cbt::RowRange::InfiniteRange(),
             cbt::Filter::Chain(CreateColumnsFilter(columns_),
                                cbt::Filter::Latest(1)))),
@@ -313,7 +313,7 @@ class Dataset : public DatasetBase {
   }
 
   BigtableClientResource& client_resource() const { return client_resource_; }
-  io::BigtableRowsetResource& row_set_resource() const { return row_set_resource_; }
+  io::BigtableRowSetResource& row_set_resource() const { return row_set_resource_; }
 
  protected:
   Status AsGraphDefInternal(SerializationContext* ctx,
@@ -327,7 +327,7 @@ class Dataset : public DatasetBase {
 
  private:
   BigtableClientResource& client_resource_;
-  io::BigtableRowSetResource* row_set_resource_;
+  io::BigtableRowSetResource& row_set_resource_;
   const std::string table_id_;
   const std::vector<std::string> columns_;
   DataTypeVector dtypes_;

--- a/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
@@ -88,9 +88,7 @@ class BigtableClientResource : public ResourceBase {
     return cbt::Table(data_client_, table_id);
   }
 
-  ~BigtableClientResource(){
-    VLOG(1) << "BigtableClientResource dtor";
-  }
+  ~BigtableClientResource() { VLOG(1) << "BigtableClientResource dtor"; }
 
   string DebugString() const override { return "BigtableClientResource"; }
 
@@ -112,9 +110,7 @@ class BigtableClientOp : public OpKernel {
     VLOG(1) << "BigtableClientOp ctor";
   }
 
-  ~BigtableClientOp(){
-    VLOG(1) << "BigtableClientOp dtor";
-  }
+  ~BigtableClientOp() { VLOG(1) << "BigtableClientOp dtor"; }
 
   void Compute(OpKernelContext* ctx) override TF_LOCKS_EXCLUDED(mu_) {
     VLOG(1) << "BigtableClientOp compute";

--- a/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 #include "absl/memory/memory.h"
+#include "google/cloud/bigtable/row_set.h"
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/table_admin.h"
 #include "tensorflow/core/framework/common_shape_fns.h"
@@ -145,7 +146,7 @@ class Iterator : public DatasetIterator<Dataset> {
         columns_(ColumnsToFamiliesAndQualifiers(columns)),
         reader_(
             this->dataset()->client_resource().CreateTable(table_id).ReadRows(
-                cbt::RowRange::InfiniteRange(),
+                cbt::RowSet(cbt::RowRange::InfiniteRange()),
                 cbt::Filter::Chain(CreateColumnsFilter(columns_),
                                    cbt::Filter::Latest(1)))),
         it_(this->reader_.begin()),

--- a/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
@@ -88,6 +88,10 @@ class BigtableClientResource : public ResourceBase {
     return cbt::Table(data_client_, table_id);
   }
 
+  ~BigtableClientResource(){
+    VLOG(1) << "BigtableClientResource dtor";
+  }
+
   string DebugString() const override { return "BigtableClientResource"; }
 
  private:
@@ -106,6 +110,10 @@ class BigtableClientOp : public OpKernel {
     OP_REQUIRES_OK(ctx, ctx->GetAttr("project_id", &project_id_));
     OP_REQUIRES_OK(ctx, ctx->GetAttr("instance_id", &instance_id_));
     VLOG(1) << "BigtableClientOp ctor";
+  }
+
+  ~BigtableClientOp(){
+    VLOG(1) << "BigtableClientOp dtor";
   }
 
   void Compute(OpKernelContext* ctx) override TF_LOCKS_EXCLUDED(mu_) {

--- a/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
@@ -152,7 +152,6 @@ class Iterator : public DatasetIterator<Dataset> {
         table_(this->dataset()->client_resource().CreateTable(table_id)),
         reader_(this->table_.ReadRows(
             this->dataset()->row_set_resource().row_set(),
-            // cbt::RowRange::InfiniteRange(),
             cbt::Filter::Chain(CreateColumnsFilter(columns_),
                                cbt::Filter::Latest(1)))),
         it_(this->reader_.begin()),
@@ -396,10 +395,10 @@ bool RowSetIntersectsRange(cbt::RowSet const& row_set,
   return !row_set.Intersect(range).IsEmpty();
 }
 
-class BigtableSampleRowSetsOp : public OpKernel {
+class BigtableSplitRowSetEvenlyOp : public OpKernel {
  public:
-  explicit BigtableSampleRowSetsOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
-    VLOG(1) << "BigtableSampleRowSetsOp ctor ";
+  explicit BigtableSplitRowSetEvenlyOp(OpKernelConstruction* ctx) : OpKernel(ctx) {
+    VLOG(1) << "BigtableSplitRowSetEvenlyOp ctor ";
     OP_REQUIRES_OK(ctx, ctx->GetAttr("table_id", &table_id_));
     OP_REQUIRES_OK(ctx,
                    ctx->GetAttr("num_parallel_calls", &num_parallel_calls_));
@@ -488,8 +487,8 @@ class BigtableSampleRowSetsOp : public OpKernel {
   int num_parallel_calls_;
 };
 
-REGISTER_KERNEL_BUILDER(Name("BigtableSampleRowSets").Device(DEVICE_CPU),
-                        BigtableSampleRowSetsOp);
+REGISTER_KERNEL_BUILDER(Name("BigtableSplitRowSetEvenly").Device(DEVICE_CPU),
+                        BigtableSplitRowSetEvenlyOp);
 
 }  // namespace
 }  // namespace data

--- a/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
@@ -264,7 +264,6 @@ class Iterator : public DatasetIterator<Dataset> {
 
   mutex mu_;
   const std::vector<std::pair<std::string, std::string>> columns_;
-  // cbt::Table table_;
   cbt::RowReader reader_ GUARDED_BY(mu_);
   cbt::v1::internal::RowReaderIterator it_ GUARDED_BY(mu_);
   // we're using a map with const refs to avoid copying strings when searching

--- a/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
@@ -281,7 +281,6 @@ class Dataset : public DatasetBase {
           std::string table_id, std::vector<std::string> columns)
       : DatasetBase(DatasetContext(ctx)),
         client_resource_(*client_resource),
-        client_resource_unref_(client_resource),
         table_id_(table_id),
         columns_(columns) {
     dtypes_.push_back(DT_STRING);
@@ -321,7 +320,6 @@ class Dataset : public DatasetBase {
 
  private:
   BigtableClientResource& client_resource_;
-  const core::ScopedUnref client_resource_unref_;
   const std::string table_id_;
   const std::vector<std::string> columns_;
   DataTypeVector dtypes_;

--- a/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_dataset_kernel.cc
@@ -30,7 +30,8 @@ namespace tensorflow {
 namespace data {
 namespace {
 
-tensorflow::error::Code GoogleCloudErrorCodeToTfErrorCode(::google::cloud::StatusCode code) {
+tensorflow::error::Code GoogleCloudErrorCodeToTfErrorCode(
+    ::google::cloud::StatusCode code) {
   switch (code) {
     case ::google::cloud::StatusCode::kOk:
       return ::tensorflow::error::OK;
@@ -73,9 +74,9 @@ Status GoogleCloudStatusToTfStatus(const ::google::cloud::Status& status) {
   if (status.ok()) {
     return Status::OK();
   }
-  return Status(GoogleCloudErrorCodeToTfErrorCode(status.code()),
-                strings::StrCat("Error reading from Cloud Bigtable: ",
-                                status.message()));
+  return Status(
+      GoogleCloudErrorCodeToTfErrorCode(status.code()),
+      strings::StrCat("Error reading from Cloud Bigtable: ", status.message()));
 }
 
 class BigtableClientResource : public ResourceBase {
@@ -313,7 +314,9 @@ class Dataset : public DatasetBase {
   }
 
   BigtableClientResource& client_resource() const { return client_resource_; }
-  io::BigtableRowSetResource& row_set_resource() const { return row_set_resource_; }
+  io::BigtableRowSetResource& row_set_resource() const {
+    return row_set_resource_;
+  }
 
  protected:
   Status AsGraphDefInternal(SerializationContext* ctx,
@@ -435,8 +438,8 @@ class BigtableSampleRowSetsOp : public OpKernel {
         std::remove_if(
             tablets.begin(), tablets.end(),
             [row_set_resource](std::pair<std::string, std::string> const& p) {
-              return !RowSetIntersectsRange(row_set_resource->row_set(), p.first,
-                                            p.second);
+              return !RowSetIntersectsRange(row_set_resource->row_set(),
+                                            p.first, p.second);
             }),
         tablets.end());
 

--- a/tensorflow_io/core/kernels/bigtable/bigtable_row_range.cc
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_row_range.cc
@@ -132,8 +132,7 @@ class BigtablePrefixRowRangeOp
   }
 
  private:
-  StatusOr<BigtableRowRangeResource*> CreateResource()
-       override {
+  StatusOr<BigtableRowRangeResource*> CreateResource() override {
     return new BigtableRowRangeResource(cbt::RowRange::Prefix(prefix_));
   }
 

--- a/tensorflow_io/core/kernels/bigtable/bigtable_row_set.cc
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_row_set.cc
@@ -151,5 +151,56 @@ class BigtableRowSetIntersectOp : public OpKernel {
 REGISTER_KERNEL_BUILDER(Name("BigtableRowSetIntersect").Device(DEVICE_CPU),
                         BigtableRowSetIntersectOp);
 
+
+class BigtableRowSetIntersectTensorOp : public OpKernel {
+ public:
+  explicit BigtableRowSetIntersectTensorOp(OpKernelConstruction* context)
+      : OpKernel(context) {}
+
+  void Compute(OpKernelContext* context) override TF_LOCKS_EXCLUDED(mu_) {
+    mutex_lock l(mu_);
+    ResourceMgr* mgr = context->resource_manager();
+    OP_REQUIRES_OK(context, cinfo_.Init(mgr, def()));
+
+    BigtableRowSetResource* row_set_resource;
+    OP_REQUIRES_OK(context, GetResourceFromContext(context, "row_set",
+                                                   &row_set_resource));
+    core::ScopedUnref row_set_resource_unref(row_set_resource);
+
+    
+    const Tensor* row_keys_tensor;
+    OP_REQUIRES_OK(context, context->input("row_range_tensor", &row_keys_tensor));
+    auto row_keys = row_keys_tensor->tensor<tstring, 1>();
+
+    VLOG(1) << "RowsetIntersectTensor intersecting: [" << row_keys(0) << "," << row_keys(1) << ")";
+
+    BigtableRowSetResource* result_resource;
+    OP_REQUIRES_OK(
+        context,
+        mgr->LookupOrCreate<BigtableRowSetResource>(
+            cinfo_.container(), cinfo_.name(), &result_resource,
+            [this, row_set_resource, &row_keys](
+                BigtableRowSetResource** ret) TF_EXCLUSIVE_LOCKS_REQUIRED(mu_) {
+              *ret = new BigtableRowSetResource(
+                  row_set_resource->Intersect(
+                      cbt::RowRange::RightOpen(row_keys(0), row_keys(1))
+                  ));
+              return Status::OK();
+            }));
+
+    OP_REQUIRES_OK(context, MakeResourceHandleToOutput(
+                                context, 0, cinfo_.container(), cinfo_.name(),
+                                TypeIndex::Make<BigtableRowSetResource>()));
+  }
+
+ protected:
+  // Variables accessible from subclasses.
+  mutex mu_;
+  ContainerInfo cinfo_ TF_GUARDED_BY(mu_);
+};
+
+REGISTER_KERNEL_BUILDER(Name("BigtableRowSetIntersectTensor").Device(DEVICE_CPU),
+                        BigtableRowSetIntersectTensorOp);
+
 }  // namespace io
 }  // namespace tensorflow

--- a/tensorflow_io/core/kernels/bigtable/bigtable_row_set.h
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_row_set.h
@@ -50,6 +50,10 @@ class BigtableRowSetResource : public ResourceBase {
     return row_set_.Intersect(row_range);
   }
 
+  google::cloud::bigtable::RowSet const& row_set(){
+      return row_set_;
+  }
+
   string DebugString() const override {
     return "BigtableRowSetResource:{" + ToString() + "}";
   }

--- a/tensorflow_io/core/kernels/bigtable/bigtable_row_set.h
+++ b/tensorflow_io/core/kernels/bigtable/bigtable_row_set.h
@@ -16,7 +16,6 @@ limitations under the License.
 #ifndef BIGTABLE_ROW_SET_H
 #define BIGTABLE_ROW_SET_H
 
-
 #include "google/cloud/bigtable/table.h"
 #include "tensorflow/core/framework/op_kernel.h"
 #include "tensorflow/core/framework/resource_mgr.h"
@@ -50,9 +49,7 @@ class BigtableRowSetResource : public ResourceBase {
     return row_set_.Intersect(row_range);
   }
 
-  google::cloud::bigtable::RowSet const& row_set(){
-      return row_set_;
-  }
+  google::cloud::bigtable::RowSet const& row_set() { return row_set_; }
 
   string DebugString() const override {
     return "BigtableRowSetResource:{" + ToString() + "}";

--- a/tensorflow_io/core/kernels/gsmemcachedfs/memcached_file_block_cache.cc
+++ b/tensorflow_io/core/kernels/gsmemcachedfs/memcached_file_block_cache.cc
@@ -759,7 +759,7 @@ int64 MemcachedFileBlockCache::AddToCacheBuffer(const string& memc_key,
     cache_buffer_keys_.push_back(memc_key);
     auto page = absl::make_unique<std::vector<char>>();
     page->assign(data->begin(), data->end());
-    cache_buffer_map_.emplace(memc_key, std::move(page));
+    cache_buffer_map_.emplace(memc_key, page.release());
   }
   return cache_buffer_keys_.size();
 }

--- a/tensorflow_io/core/kernels/gsmemcachedfs/memcached_file_block_cache.cc
+++ b/tensorflow_io/core/kernels/gsmemcachedfs/memcached_file_block_cache.cc
@@ -759,7 +759,7 @@ int64 MemcachedFileBlockCache::AddToCacheBuffer(const string& memc_key,
     cache_buffer_keys_.push_back(memc_key);
     auto page = absl::make_unique<std::vector<char>>();
     page->assign(data->begin(), data->end());
-    cache_buffer_map_.emplace(memc_key, page.release());
+    cache_buffer_map_.emplace(memc_key, std::move(page));
   }
   return cache_buffer_keys_.size();
 }

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -103,12 +103,3 @@ REGISTER_OP("BigtableSampleRowKeys")
       return tensorflow::Status::OK();
     });
 
-
-REGISTER_OP("BigtableSplitWork")
-    .Input("")
-    .Attr("table_id: string")
-    .Output("samples: string")
-    .SetShapeFn([](tensorflow::shape_inference::InferenceContext* c) {
-      c->set_output(0, c->Vector(c->UnknownDim()));
-      return tensorflow::Status::OK();
-    });

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -103,3 +103,12 @@ REGISTER_OP("BigtableSampleRowKeys")
       return tensorflow::Status::OK();
     });
 
+
+REGISTER_OP("BigtableSampleRowSets")
+    .Input("client: resource")
+    .Attr("table_id: string")
+    .Output("samples: string")
+    .SetShapeFn([](tensorflow::shape_inference::InferenceContext* c) {
+      c->set_output(0, c->MakeShape({}));
+      return tensorflow::Status::OK();
+    });

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -93,6 +93,14 @@ REGISTER_OP("BigtableRowSetIntersect")
     .Output("result_row_set: resource")
     .SetShapeFn(shape_inference::ScalarShape);
 
+REGISTER_OP("BigtableRowsetIntersectTensor")
+    .Attr("container: string = ''")
+    .Attr("shared_name: string = ''")
+    .Input("row_set_resource: resource")
+    .Input("row_range_tensor: string")
+    .Output("row_set: resource")
+    .SetShapeFn(shape_inference::UnchangedShape);
+
 
 REGISTER_OP("BigtableSampleRowKeys")
     .Input("client: resource")
@@ -111,6 +119,6 @@ REGISTER_OP("BigtableSampleRowSets")
     .Attr("num_parallel_calls: int")
     .Output("samples: string")
     .SetShapeFn([](tensorflow::shape_inference::InferenceContext* c) {
-      c->set_output(0, c->MakeShape({}));
+      c->set_output(0, c->Vector(c->UnknownDim()));
       return tensorflow::Status::OK();
     });

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -103,16 +103,6 @@ REGISTER_OP("BigtableRowsetIntersectTensor")
     .SetShapeFn(shape_inference::UnchangedShape);
 
 
-REGISTER_OP("BigtableSampleRowKeys")
-    .Input("client: resource")
-    .Attr("table_id: string")
-    .Output("samples: string")
-    .SetShapeFn([](tensorflow::shape_inference::InferenceContext* c) {
-      c->set_output(0, c->Vector(c->UnknownDim()));
-      return tensorflow::Status::OK();
-    });
-
-
 REGISTER_OP("BigtableSampleRowSets")
     .Input("client: resource")
     .Input("row_set: resource")

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -93,7 +93,7 @@ REGISTER_OP("BigtableRowSetIntersect")
     .Output("result_row_set: resource")
     .SetShapeFn(shape_inference::ScalarShape);
 
-REGISTER_OP("BigtableSampleRowSets")
+REGISTER_OP("BigtableSplitRowSetEvenly")
     .Attr("container: string = ''")
     .Attr("shared_name: string = ''")
     .Input("client: resource")

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -94,12 +94,12 @@ REGISTER_OP("BigtableRowSetIntersect")
     .Output("result_row_set: resource")
     .SetShapeFn(shape_inference::ScalarShape);
 
-REGISTER_OP("BigtableRowsetIntersectTensor")
+REGISTER_OP("BigtableRowSetIntersectTensor")
     .Attr("container: string = ''")
     .Attr("shared_name: string = ''")
-    .Input("row_set_resource: resource")
+    .Input("row_set: resource")
     .Input("row_range_tensor: string")
-    .Output("row_set: resource")
+    .Output("result_row_set: resource")
     .SetShapeFn(shape_inference::UnchangedShape);
 
 

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -27,6 +27,7 @@ REGISTER_OP("BigtableClient")
 
 REGISTER_OP("BigtableDataset")
     .Input("client: resource")
+    .Input("row_set: resource")
     .Attr("table_id: string")
     .Attr("columns: list(string) >= 1")
     .Output("handle: variant")

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -34,7 +34,6 @@ REGISTER_OP("BigtableDataset")
     .SetIsStateful()
     .SetShapeFn(shape_inference::ScalarShape);
 
-
 REGISTER_OP("BigtableEmptyRowSet")
     .Attr("container: string = ''")
     .Attr("shared_name: string = ''")
@@ -93,7 +92,6 @@ REGISTER_OP("BigtableRowSetIntersect")
     .Input("row_range: resource")
     .Output("result_row_set: resource")
     .SetShapeFn(shape_inference::ScalarShape);
-
 
 REGISTER_OP("BigtableSampleRowSets")
     .Attr("container: string = ''")

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -106,7 +106,9 @@ REGISTER_OP("BigtableSampleRowKeys")
 
 REGISTER_OP("BigtableSampleRowSets")
     .Input("client: resource")
+    .Input("row_set: resource")
     .Attr("table_id: string")
+    .Attr("num_parallel_calls: int")
     .Output("samples: string")
     .SetShapeFn([](tensorflow::shape_inference::InferenceContext* c) {
       c->set_output(0, c->MakeShape({}));

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -93,3 +93,12 @@ REGISTER_OP("BigtableRowSetIntersect")
     .Output("result_row_set: resource")
     .SetShapeFn(shape_inference::ScalarShape);
 
+
+REGISTER_OP("BigtableSampleRowKeys")
+    .Input("client: resource")
+    .Attr("table_id: string")
+    .Output("samples: string")
+    .SetShapeFn([](tensorflow::shape_inference::InferenceContext* c) {
+      c->set_output(0, c->Vector(c->UnknownDim()));
+      return tensorflow::Status::OK();
+    });

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -102,3 +102,13 @@ REGISTER_OP("BigtableSampleRowKeys")
       c->set_output(0, c->Vector(c->UnknownDim()));
       return tensorflow::Status::OK();
     });
+
+
+REGISTER_OP("BigtableSplitWork")
+    .Input("")
+    .Attr("table_id: string")
+    .Output("samples: string")
+    .SetShapeFn([](tensorflow::shape_inference::InferenceContext* c) {
+      c->set_output(0, c->Vector(c->UnknownDim()));
+      return tensorflow::Status::OK();
+    });

--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -99,7 +99,7 @@ REGISTER_OP("BigtableSplitRowSetEvenly")
     .Input("client: resource")
     .Input("row_set: resource")
     .Attr("table_id: string")
-    .Attr("num_parallel_calls: int")
+    .Attr("num_splits: int")
     .Output("samples: resource")
     .SetIsStateful()
     .SetShapeFn([](tensorflow::shape_inference::InferenceContext* c) {

--- a/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
@@ -36,11 +36,7 @@ class BigtableTable:
         return _BigtableDataset(self._client_resource, self._table_id, columns, row_set)
     
     def parallel_read_rows(self, columns: List[str], num_parallel_calls=1, row_set: RowSet=from_rows_or_ranges(infinite())):
-        print("asdadsasddsadsadsada")
-        print("getting samples")
         samples = core_ops.bigtable_sample_row_sets(self._client_resource, row_set._impl, self._table_id, num_parallel_calls)
-        print("$"*50)
-        print("got samples")
         samples_ds = dataset_ops.Dataset.from_tensor_slices(samples)
         def map_func(sample):
             rs = RowSet(core_ops.bigtable_rowset_intersect_tensor(row_set._impl, sample))

--- a/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
@@ -40,9 +40,11 @@ class BigtableTable:
     def parallel_read_rows(
         self,
         columns: List[str],
-        num_parallel_calls=1,
+        num_parallel_calls=tf.data.AUTOTUNE,
         row_set: RowSet = from_rows_or_ranges(infinite()),
     ):
+
+        print("calling parallel read_rows with row_set:", row_set)
         samples = core_ops.bigtable_split_row_set_evenly(
             self._client_resource, row_set._impl, self._table_id, num_parallel_calls,
         )

--- a/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
@@ -43,7 +43,7 @@ class BigtableTable:
         num_parallel_calls=1,
         row_set: RowSet = from_rows_or_ranges(infinite()),
     ):
-        samples = core_ops.bigtable_sample_row_sets(
+        samples = core_ops.bigtable_split_row_set_evenly(
             self._client_resource, row_set._impl, self._table_id, num_parallel_calls,
         )
 

--- a/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
@@ -37,7 +37,9 @@ class BigtableTable:
         self._client_resource = client_resource
 
     def read_rows(self, columns: List[str], row_set: RowSet):
-        return _BigtableDataset(self._client_resource, self._table_id, columns, row_set)
+        return _BigtableDataset(
+            self._client_resource, self._table_id, columns, row_set
+        )
 
     def parallel_read_rows(
         self,
@@ -46,13 +48,18 @@ class BigtableTable:
         row_set: RowSet = from_rows_or_ranges(infinite()),
     ):
         samples = core_ops.bigtable_sample_row_sets(
-            self._client_resource, row_set._impl, self._table_id, num_parallel_calls
+            self._client_resource,
+            row_set._impl,
+            self._table_id,
+            num_parallel_calls,
         )
         samples_ds = dataset_ops.Dataset.from_tensor_slices(samples)
 
         def map_func(sample):
             rs = RowSet(
-                core_ops.bigtable_row_set_intersect_tensor(row_set._impl, sample)
+                core_ops.bigtable_row_set_intersect_tensor(
+                    row_set._impl, sample
+                )
             )
             return self.read_rows(columns, rs)
 
@@ -69,7 +76,11 @@ class _BigtableDataset(dataset_ops.DatasetSource):
     """_BigtableDataset represents a dataset that retrieves keys and values."""
 
     def __init__(
-        self, client_resource, table_id: str, columns: List[str], row_set: RowSet
+        self,
+        client_resource,
+        table_id: str,
+        columns: List[str],
+        row_set: RowSet,
     ):
         self._table_id = table_id
         self._columns = columns

--- a/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
@@ -52,7 +52,7 @@ class BigtableTable:
 
         def map_func(sample):
             rs = RowSet(
-                core_ops.bigtable_rowset_intersect_tensor(row_set._impl, sample)
+                core_ops.bigtable_row_set_intersect_tensor(row_set._impl, sample)
             )
             return self.read_rows(columns, rs)
 

--- a/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
@@ -50,6 +50,7 @@ class BigtableTable:
 
 
 
+
 class _BigtableDataset(dataset_ops.DatasetSource):
     """_BigtableDataset represents a dataset that retrieves keys and values."""
 

--- a/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
@@ -6,8 +6,8 @@ from tensorflow.python.framework import dtypes
 import tensorflow as tf
 from tensorflow.python.data.ops import dataset_ops
 
-from tensorflow_io.python.ops.bigtable.bigtable_row_set import from_rows_or_ranges, RowSet, intersect
-from tensorflow_io.python.ops.bigtable.bigtable_row_range import infinite, right_open
+from tensorflow_io.python.ops.bigtable.bigtable_row_set import from_rows_or_ranges, RowSet
+from tensorflow_io.python.ops.bigtable.bigtable_row_range import infinite
 
 
 class BigtableClient:

--- a/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_dataset_ops.py
@@ -39,10 +39,8 @@ class BigtableTable:
         samples = core_ops.bigtable_sample_row_sets(self._client_resource, row_set._impl, self._table_id, num_parallel_calls)
         samples_ds = dataset_ops.Dataset.from_tensor_slices(samples)
         def map_func(sample):
-            print("lalalal_mysample:", sample)
-            print("lslslsample:", dir(sample[0]))
-            rs = intersect(row_set, right_open(sample[0], sample[1]))
-            return self.read_rows(columns, rs)
+            rs = RowSet(core_ops.bigtable_rowset_intersect_tensor(row_set._impl, sample))
+            return self.read_rows(columns,rs)
 
         return samples_ds.interleave(
             map_func=map_func,

--- a/tensorflow_io/python/ops/bigtable/bigtable_row_range.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_row_range.py
@@ -15,7 +15,6 @@
 """Module implementing basic functions for obtaining BigTable RowRanges"""
 
 from tensorflow_io.python.ops import core_ops
-import tensorflow
 
 
 class RowRange:

--- a/tensorflow_io/python/ops/bigtable/bigtable_row_set.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_row_set.py
@@ -14,7 +14,6 @@
 
 """Module implementing basic functions for obtaining BigTable RowSets"""
 
-from tensorflow.python.framework import dtypes
 from tensorflow_io.python.ops import core_ops
 from . import bigtable_row_range
 from typing import Union

--- a/tensorflow_io/python/ops/bigtable/bigtable_row_set.py
+++ b/tensorflow_io/python/ops/bigtable/bigtable_row_set.py
@@ -30,9 +30,7 @@ class RowSet:
         if isinstance(row_or_range, str):
             core_ops.bigtable_row_set_append_row(self._impl, row_or_range)
         else:
-            core_ops.bigtable_row_set_append_row_range(
-                self._impl, row_or_range._impl
-            )
+            core_ops.bigtable_row_set_append_row_range(self._impl, row_or_range._impl)
 
 
 def empty():
@@ -71,6 +69,4 @@ def intersect(row_set: RowSet, row_range: bigtable_row_range.RowRange):
     Returns:
       RowSet: an intersection of the given row set and row range.
     """
-    return RowSet(
-        core_ops.bigtable_row_set_intersect(row_set._impl, row_range._impl)
-    )
+    return RowSet(core_ops.bigtable_row_set_intersect(row_set._impl, row_range._impl))

--- a/tests/test_bigtable/bigtable_emulator.py
+++ b/tests/test_bigtable/bigtable_emulator.py
@@ -67,9 +67,7 @@ def _get_cbt_emulator_path():
 
 
 def _get_cbt_cli_path():
-    return _get_cbt_binary_path(
-        CBT_CLI_PATH_ENV_VAR, CBT_CLI_SEARCH_PATHS, "cbt cli"
-    )
+    return _get_cbt_binary_path(CBT_CLI_PATH_ENV_VAR, CBT_CLI_SEARCH_PATHS, "cbt cli")
 
 
 def _extract_emulator_addr_from_output(emulator_output):
@@ -82,9 +80,7 @@ def _extract_emulator_addr_from_output(emulator_output):
             for word in words:
                 if re.fullmatch("[a-z.0-9]+:[0-9]+", word):
                     return word
-            raise RuntimeError(
-                f"Failed to find CBT emulator in the line {line}"
-            )
+            raise RuntimeError(f"Failed to find CBT emulator in the line {line}")
 
 
 class BigtableEmulator:

--- a/tests/test_bigtable/test_parallel_read_rows.py
+++ b/tests/test_bigtable/test_parallel_read_rows.py
@@ -19,6 +19,7 @@
 
 import os
 from .bigtable_emulator import BigtableEmulator
+from tensorflow_io.python.ops import core_ops
 from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import BigtableClient
 import tensorflow_io.python.ops.bigtable.bigtable_row_range as row_range
 import tensorflow_io.python.ops.bigtable.bigtable_row_set as row_set
@@ -51,3 +52,55 @@ class BigtableParallelReadTest(test.TestCase):
         for i, r in enumerate(table.parallel_read_rows(["fam1:col1", "fam2:col2"], row_set=row_set.from_rows_or_ranges(row_range.empty()))):
             for j, c in enumerate(r):
                 self.assertEqual(values[i][j], c.numpy().decode())
+
+    def test_not_parallel_read(self):
+        os.environ["BIGTABLE_EMULATOR_HOST"] = self.emulator.get_addr()
+        self.emulator.create_table("fake_project", "fake_instance", "test-table",
+                                   ["fam1", "fam2"], splits=["row005", "row010", "row015"])
+
+        values = [[f"[{i,j}]" for j in range(2)] for i in range(20)]
+
+        ten = tf.constant(values)
+
+        client = BigtableClient("fake_project", "fake_instance")
+        table = client.get_table("test-table")
+
+        self.emulator.write_tensor("fake_project", "fake_instance", "test-table", ten,
+                                   ["row" + str(i).rjust(3, "0") for i in range(20)],  ["fam1:col1", "fam2:col2"])
+
+        for i, r in enumerate(table.parallel_read_rows(["fam1:col1", "fam2:col2"], row_set=row_set.from_rows_or_ranges(row_range.empty()), num_parallel_calls=2)):
+            for j, c in enumerate(r):
+                self.assertEqual(values[i][j], c.numpy().decode())
+
+    def test_sample_row_sets(self):
+        os.environ["BIGTABLE_EMULATOR_HOST"] = self.emulator.get_addr()
+        self.emulator.create_table("fake_project", "fake_instance", "test-table",
+                                   ["fam1", "fam2"], splits=["row005", "row010", "row015", "row020", "row025", "row030"])
+
+        values = [[f"[{i,j}]" for j in range(2)] for i in range(40)]
+
+        ten = tf.constant(values)
+
+        client = BigtableClient("fake_project", "fake_instance")
+
+        self.emulator.write_tensor("fake_project", "fake_instance", "test-table", ten,
+                                   ["row" + str(i).rjust(3, "0") for i in range(40)],  ["fam1:col1", "fam2:col2"])
+
+        rs = row_set.from_rows_or_ranges(row_range.infinite())
+
+        num_parallel_calls = 2
+        samples = [s for s in core_ops.bigtable_sample_row_sets(client._client_resource, rs._impl, "test-table", num_parallel_calls)]
+        self.assertEqual(len(samples), num_parallel_calls)
+
+        num_parallel_calls = 6
+        samples = [s for s in core_ops.bigtable_sample_row_sets(client._client_resource, rs._impl, "test-table", num_parallel_calls)]
+        
+        # The emulator may return different samples each time, so we can't
+        # expect an exact number, but it must be no more than num_parallel_calls
+        self.assertLessEqual(len(samples), num_parallel_calls)
+
+        num_parallel_calls = 1
+        samples = [s for s in core_ops.bigtable_sample_row_sets(client._client_resource, rs._impl, "test-table", num_parallel_calls)]
+        self.assertEqual(len(samples), num_parallel_calls)
+        self.assertEqual(samples[0].numpy()[0].decode(), "")
+        self.assertEqual(samples[0].numpy()[1].decode(), "")

--- a/tests/test_bigtable/test_parallel_read_rows.py
+++ b/tests/test_bigtable/test_parallel_read_rows.py
@@ -1,0 +1,53 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# disable module docstring for tests
+# pylint: disable=C0114
+# disable class docstring for tests
+# pylint: disable=C0115
+
+import os
+from .bigtable_emulator import BigtableEmulator
+from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import BigtableClient
+import tensorflow_io.python.ops.bigtable.bigtable_row_range as row_range
+import tensorflow_io.python.ops.bigtable.bigtable_row_set as row_set
+import tensorflow as tf
+from tensorflow import test
+
+
+class BigtableParallelReadTest(test.TestCase):
+    def setUp(self):
+        self.emulator = BigtableEmulator()
+
+    def tearDown(self):
+        self.emulator.stop()
+
+    def test_parallel_read(self):
+        os.environ["BIGTABLE_EMULATOR_HOST"] = self.emulator.get_addr()
+        self.emulator.create_table("fake_project", "fake_instance", "test-table",
+                                   ["fam1", "fam2"], splits=["row005", "row010", "row015"])
+
+        values = [[f"[{i,j}]" for j in range(2)] for i in range(20)]
+
+        ten = tf.constant(values)
+
+        client = BigtableClient("fake_project", "fake_instance")
+        table = client.get_table("test-table")
+
+        self.emulator.write_tensor("fake_project", "fake_instance", "test-table", ten,
+                                   ["row" + str(i).rjust(3, "0") for i in range(20)],  ["fam1:col1", "fam2:col2"])
+
+        for i, r in enumerate(table.parallel_read_rows(["fam1:col1", "fam2:col2"], row_set=row_set.from_rows_or_ranges(row_range.empty()))):
+            for j, c in enumerate(r):
+                self.assertEqual(values[i][j], c.numpy().decode())

--- a/tests/test_bigtable/test_parallel_read_rows.py
+++ b/tests/test_bigtable/test_parallel_read_rows.py
@@ -21,7 +21,9 @@ import os
 from re import escape
 from .bigtable_emulator import BigtableEmulator
 from tensorflow_io.python.ops import core_ops
-from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import BigtableClient
+from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import (
+    BigtableClient,
+)
 import tensorflow_io.python.ops.bigtable.bigtable_row_range as row_range
 import tensorflow_io.python.ops.bigtable.bigtable_row_set as row_set
 import tensorflow as tf
@@ -95,15 +97,13 @@ class BigtableParallelReadTest(test.TestCase):
             ["fam1:col1", "fam2:col2"],
         )
 
-        for i, r in enumerate(
-            table.parallel_read_rows(
-                ["fam1:col1", "fam2:col2"],
-                row_set=row_set.from_rows_or_ranges(row_range.empty()),
-                num_parallel_calls=2,
-            )
-        ):
-            for j, c in enumerate(r):
-                self.assertEqual(values[i][j], c.numpy().decode())
+        dataset = table.parallel_read_rows(
+            ["fam1:col1", "fam2:col2"],
+            row_set=row_set.from_rows_or_ranges(row_range.infinite()),
+            num_parallel_calls=2,
+        )
+        results = [[v.numpy().decode() for v in row] for row in dataset]
+        self.assertEqual(repr(sorted(values)), repr(sorted(results)))
 
     def test_split_row_set(self):
         os.environ["BIGTABLE_EMULATOR_HOST"] = self.emulator.get_addr()
@@ -136,7 +136,10 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_split_row_set_evenly(
-                client._client_resource, rs._impl, "test-table", num_parallel_calls,
+                client._client_resource,
+                rs._impl,
+                "test-table",
+                num_parallel_calls,
             )
         ]
         self.assertEqual(len(samples), num_parallel_calls)
@@ -145,7 +148,10 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_split_row_set_evenly(
-                client._client_resource, rs._impl, "test-table", num_parallel_calls,
+                client._client_resource,
+                rs._impl,
+                "test-table",
+                num_parallel_calls,
             )
         ]
 
@@ -157,7 +163,10 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_split_row_set_evenly(
-                client._client_resource, rs._impl, "test-table", num_parallel_calls,
+                client._client_resource,
+                rs._impl,
+                "test-table",
+                num_parallel_calls,
             )
         ]
         self.assertEqual(len(samples), num_parallel_calls)
@@ -165,7 +174,10 @@ class BigtableParallelReadTest(test.TestCase):
     def test_split_empty(self):
         os.environ["BIGTABLE_EMULATOR_HOST"] = self.emulator.get_addr()
         self.emulator.create_table(
-            "fake_project", "fake_instance", "test-table", ["fam1", "fam2"],
+            "fake_project",
+            "fake_instance",
+            "test-table",
+            ["fam1", "fam2"],
         )
 
         client = BigtableClient("fake_project", "fake_instance")
@@ -177,6 +189,9 @@ class BigtableParallelReadTest(test.TestCase):
         self.assertRaises(
             tf.errors.FailedPreconditionError,
             lambda: core_ops.bigtable_split_row_set_evenly(
-                client._client_resource, rs._impl, "test-table", num_parallel_calls,
+                client._client_resource,
+                rs._impl,
+                "test-table",
+                num_parallel_calls,
             ),
         )

--- a/tests/test_bigtable/test_parallel_read_rows.py
+++ b/tests/test_bigtable/test_parallel_read_rows.py
@@ -20,9 +20,7 @@
 import os
 from .bigtable_emulator import BigtableEmulator
 from tensorflow_io.python.ops import core_ops
-from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import (
-    BigtableClient,
-)
+from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import BigtableClient
 import tensorflow_io.python.ops.bigtable.bigtable_row_range as row_range
 import tensorflow_io.python.ops.bigtable.bigtable_row_set as row_set
 import tensorflow as tf
@@ -138,10 +136,7 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_sample_row_sets(
-                client._client_resource,
-                rs._impl,
-                "test-table",
-                num_parallel_calls,
+                client._client_resource, rs._impl, "test-table", num_parallel_calls,
             )
         ]
         self.assertEqual(len(samples), num_parallel_calls)
@@ -150,10 +145,7 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_sample_row_sets(
-                client._client_resource,
-                rs._impl,
-                "test-table",
-                num_parallel_calls,
+                client._client_resource, rs._impl, "test-table", num_parallel_calls,
             )
         ]
 
@@ -165,10 +157,7 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_sample_row_sets(
-                client._client_resource,
-                rs._impl,
-                "test-table",
-                num_parallel_calls,
+                client._client_resource, rs._impl, "test-table", num_parallel_calls,
             )
         ]
         self.assertEqual(len(samples), num_parallel_calls)

--- a/tests/test_bigtable/test_parallel_read_rows.py
+++ b/tests/test_bigtable/test_parallel_read_rows.py
@@ -20,7 +20,9 @@
 import os
 from .bigtable_emulator import BigtableEmulator
 from tensorflow_io.python.ops import core_ops
-from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import BigtableClient
+from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import (
+    BigtableClient,
+)
 import tensorflow_io.python.ops.bigtable.bigtable_row_range as row_range
 import tensorflow_io.python.ops.bigtable.bigtable_row_set as row_set
 import tensorflow as tf
@@ -136,7 +138,10 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_sample_row_sets(
-                client._client_resource, rs._impl, "test-table", num_parallel_calls
+                client._client_resource,
+                rs._impl,
+                "test-table",
+                num_parallel_calls,
             )
         ]
         self.assertEqual(len(samples), num_parallel_calls)
@@ -145,7 +150,10 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_sample_row_sets(
-                client._client_resource, rs._impl, "test-table", num_parallel_calls
+                client._client_resource,
+                rs._impl,
+                "test-table",
+                num_parallel_calls,
             )
         ]
 
@@ -157,7 +165,10 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_sample_row_sets(
-                client._client_resource, rs._impl, "test-table", num_parallel_calls
+                client._client_resource,
+                rs._impl,
+                "test-table",
+                num_parallel_calls,
             )
         ]
         self.assertEqual(len(samples), num_parallel_calls)

--- a/tests/test_bigtable/test_parallel_read_rows.py
+++ b/tests/test_bigtable/test_parallel_read_rows.py
@@ -21,9 +21,7 @@ import os
 from re import escape
 from .bigtable_emulator import BigtableEmulator
 from tensorflow_io.python.ops import core_ops
-from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import (
-    BigtableClient,
-)
+from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import BigtableClient
 import tensorflow_io.python.ops.bigtable.bigtable_row_range as row_range
 import tensorflow_io.python.ops.bigtable.bigtable_row_set as row_set
 import tensorflow as tf
@@ -136,10 +134,7 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_split_row_set_evenly(
-                client._client_resource,
-                rs._impl,
-                "test-table",
-                num_parallel_calls,
+                client._client_resource, rs._impl, "test-table", num_parallel_calls,
             )
         ]
         self.assertEqual(len(samples), num_parallel_calls)
@@ -148,10 +143,7 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_split_row_set_evenly(
-                client._client_resource,
-                rs._impl,
-                "test-table",
-                num_parallel_calls,
+                client._client_resource, rs._impl, "test-table", num_parallel_calls,
             )
         ]
 
@@ -163,10 +155,7 @@ class BigtableParallelReadTest(test.TestCase):
         samples = [
             s
             for s in core_ops.bigtable_split_row_set_evenly(
-                client._client_resource,
-                rs._impl,
-                "test-table",
-                num_parallel_calls,
+                client._client_resource, rs._impl, "test-table", num_parallel_calls,
             )
         ]
         self.assertEqual(len(samples), num_parallel_calls)
@@ -174,10 +163,7 @@ class BigtableParallelReadTest(test.TestCase):
     def test_split_empty(self):
         os.environ["BIGTABLE_EMULATOR_HOST"] = self.emulator.get_addr()
         self.emulator.create_table(
-            "fake_project",
-            "fake_instance",
-            "test-table",
-            ["fam1", "fam2"],
+            "fake_project", "fake_instance", "test-table", ["fam1", "fam2"],
         )
 
         client = BigtableClient("fake_project", "fake_instance")
@@ -189,9 +175,6 @@ class BigtableParallelReadTest(test.TestCase):
         self.assertRaises(
             tf.errors.FailedPreconditionError,
             lambda: core_ops.bigtable_split_row_set_evenly(
-                client._client_resource,
-                rs._impl,
-                "test-table",
-                num_parallel_calls,
+                client._client_resource, rs._impl, "test-table", num_parallel_calls,
             ),
         )

--- a/tests/test_bigtable/test_read_rows.py
+++ b/tests/test_bigtable/test_read_rows.py
@@ -19,9 +19,7 @@
 
 import os
 from .bigtable_emulator import BigtableEmulator
-from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import (
-    BigtableClient,
-)
+from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import BigtableClient
 import tensorflow_io.python.ops.bigtable.bigtable_row_range as row_range
 import tensorflow_io.python.ops.bigtable.bigtable_row_set as row_set
 import tensorflow as tf
@@ -88,12 +86,9 @@ class BigtableReadTest(test.TestCase):
             ["fam1:col1", "fam2:col2"],
         )
 
-        row_s = row_set.from_rows_or_ranges(
-            row_range.closed_range("row000", "row009")
-        )
+        row_s = row_set.from_rows_or_ranges(row_range.closed_range("row000", "row009"))
 
         read_rows = [
-            r
-            for r in table.read_rows(["fam1:col1", "fam2:col2"], row_set=row_s)
+            r for r in table.read_rows(["fam1:col1", "fam2:col2"], row_set=row_s)
         ]
         self.assertEqual(len(read_rows), 10)

--- a/tests/test_bigtable/test_read_rows.py
+++ b/tests/test_bigtable/test_read_rows.py
@@ -22,6 +22,8 @@ from .bigtable_emulator import BigtableEmulator
 from tensorflow_io.python.ops.bigtable.bigtable_dataset_ops import (
     BigtableClient,
 )
+import tensorflow_io.python.ops.bigtable.bigtable_row_range as row_range
+import tensorflow_io.python.ops.bigtable.bigtable_row_set as row_set
 import tensorflow as tf
 from tensorflow import test
 

--- a/tests/test_bigtable/test_read_rows.py
+++ b/tests/test_bigtable/test_read_rows.py
@@ -88,9 +88,12 @@ class BigtableReadTest(test.TestCase):
             ["fam1:col1", "fam2:col2"],
         )
 
-        row_s = row_set.from_rows_or_ranges(row_range.closed_range("row000", "row009"))
+        row_s = row_set.from_rows_or_ranges(
+            row_range.closed_range("row000", "row009")
+        )
 
         read_rows = [
-            r for r in table.read_rows(["fam1:col1", "fam2:col2"], row_set=row_s)
+            r
+            for r in table.read_rows(["fam1:col1", "fam2:col2"], row_set=row_s)
         ]
         self.assertEqual(len(read_rows), 10)

--- a/tests/test_bigtable/test_row_set.py
+++ b/tests/test_bigtable/test_row_set.py
@@ -120,6 +120,6 @@ class TestRowSet(test.TestCase):
         r_range = row_range.right_open("row2", "row3")
         regular_intersect = row_set.intersect(r_set, r_range)
         tensor_intersect = row_set.RowSet(
-            core_ops.bigtable_rowset_intersect_tensor(r_set._impl, tensor)
+            core_ops.bigtable_row_set_intersect_tensor(r_set._impl, tensor)
         )
         self.assertEqual(repr(regular_intersect), repr(tensor_intersect))

--- a/tests/test_bigtable/test_row_set.py
+++ b/tests/test_bigtable/test_row_set.py
@@ -106,14 +106,10 @@ class TestRowSet(test.TestCase):
         self.assertEqual(expected, repr(r_set))
 
     def test_intersect(self):
-        r_set = row_set.from_rows_or_ranges(
-            row_range.open_range("row1", "row5")
-        )
+        r_set = row_set.from_rows_or_ranges(row_range.open_range("row1", "row5"))
         r_set = row_set.intersect(r_set, row_range.closed_range("row3", "row7"))
         expected = (
-            "row_ranges {\n"
-            + '  start_key_closed: "row3"\n'
-            + "  end_key_open: "
+            "row_ranges {\n" + '  start_key_closed: "row3"\n' + "  end_key_open: "
             '"row5"\n' + "}\n"
         )
         self.assertEqual(expected, repr(r_set))

--- a/tests/test_bigtable/test_row_set.py
+++ b/tests/test_bigtable/test_row_set.py
@@ -16,9 +16,11 @@
 # pylint: disable=C0114
 # disable class docstring for tests
 # pylint: disable=C0115
+from tensorflow_io.python.ops import core_ops
 import tensorflow_io.python.ops.bigtable.bigtable_row_range as row_range
 import tensorflow_io.python.ops.bigtable.bigtable_row_set as row_set
 from tensorflow import test
+import tensorflow as tf
 
 
 class RowRangeTest(test.TestCase):

--- a/tests/test_bigtable/test_row_set.py
+++ b/tests/test_bigtable/test_row_set.py
@@ -106,16 +106,22 @@ class TestRowSet(test.TestCase):
         self.assertEqual(expected, repr(r_set))
 
     def test_intersect(self):
-        r_set = row_set.from_rows_or_ranges(row_range.open_range("row1", "row5"))
+        r_set = row_set.from_rows_or_ranges(
+            row_range.open_range("row1", "row5")
+        )
         r_set = row_set.intersect(r_set, row_range.closed_range("row3", "row7"))
         expected = (
-            "row_ranges {\n" + '  start_key_closed: "row3"\n' + "  end_key_open: "
+            "row_ranges {\n"
+            + '  start_key_closed: "row3"\n'
+            + "  end_key_open: "
             '"row5"\n' + "}\n"
         )
         self.assertEqual(expected, repr(r_set))
 
     def test_intersect_tensor(self):
-        r_set = row_set.from_rows_or_ranges(row_range.open_range("row1", "row5"))
+        r_set = row_set.from_rows_or_ranges(
+            row_range.open_range("row1", "row5")
+        )
         tensor = tf.constant(["row2", "row3"])
         r_range = row_range.right_open("row2", "row3")
         regular_intersect = row_set.intersect(r_set, r_range)

--- a/tests/test_bigtable/test_row_set.py
+++ b/tests/test_bigtable/test_row_set.py
@@ -106,14 +106,20 @@ class TestRowSet(test.TestCase):
         self.assertEqual(expected, repr(r_set))
 
     def test_intersect(self):
-        r_set = row_set.from_rows_or_ranges(
-            row_range.open_range("row1", "row5")
-        )
+        r_set = row_set.from_rows_or_ranges(row_range.open_range("row1", "row5"))
         r_set = row_set.intersect(r_set, row_range.closed_range("row3", "row7"))
         expected = (
-            "row_ranges {\n"
-            + '  start_key_closed: "row3"\n'
-            + "  end_key_open: "
+            "row_ranges {\n" + '  start_key_closed: "row3"\n' + "  end_key_open: "
             '"row5"\n' + "}\n"
         )
         self.assertEqual(expected, repr(r_set))
+
+    def test_intersect_tensor(self):
+        r_set = row_set.from_rows_or_ranges(row_range.open_range("row1", "row5"))
+        tensor = tf.constant(["row2", "row3"])
+        r_range = row_range.right_open("row2", "row3")
+        regular_intersect = row_set.intersect(r_set, r_range)
+        tensor_intersect = row_set.RowSet(
+            core_ops.bigtable_rowset_intersect_tensor(r_set._impl, tensor)
+        )
+        self.assertEqual(repr(regular_intersect), repr(tensor_intersect))


### PR DESCRIPTION
In this pr we make the read methods accept a row_set reading only rows specified by the user.
We also add a parallel read, that leverages the sample_row_keys method to split work among workers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/tensorflow_io/4)
<!-- Reviewable:end -->
