### PR TITLE
fix: variable names in doc string

### DIFF
--- a/tensorflow_io/core/ops/bigtable_ops.cc
+++ b/tensorflow_io/core/ops/bigtable_ops.cc
@@ -199,10 +199,8 @@ REGISTER_OP("BigtableTimestampRangeFilter")
 Creates a BigtableFilterResource representing Filter passing values created 
 between `start_ts_us` and `end_ts_us`.
 
-start_timestamp: The start of the row range (inclusive) in microseconds since 
-epoch.
-end_timestamp: The end of the row range (exclusive) in microseconds since 
-epoch.
+start_ts_us: The start of the row range (inclusive) in microseconds since epoch.
+end_ts_us: The end of the row range (exclusive) in microseconds since epoch.
 )doc");
 
 REGISTER_OP("BigtablePrintFilter")


### PR DESCRIPTION
variable names in doc string were wrong which caused an error when loading library

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unoperate/tensorflow_io/11)
<!-- Reviewable:end -->
